### PR TITLE
add large interaction energy on accessible positions

### DIFF
--- a/dac_sim/widom_insertion.py
+++ b/dac_sim/widom_insertion.py
@@ -254,6 +254,7 @@ class WidomInsertion(Dynamics):
                         float("nan"),
                         float("nan"),
                     )
+                    interaction_energies[i] = 1e10  # lead to zero boltzmann factor
                     self.nsteps += 1
                     continue
 
@@ -272,7 +273,7 @@ class WidomInsertion(Dynamics):
 
                 # Handle invalid interaction energy
                 if interaction_energy < -1.25:
-                    interaction_energy = 100.0  # lead to zero boltzmann factor
+                    interaction_energy = 1e10  # lead to zero boltzmann factor
 
                 interaction_energies[i] = interaction_energy
                 boltzmann_factor = np.exp(


### PR DESCRIPTION
In the original code, positions marked as inaccessible (i.e., block regions) were initialized with an interaction energy of 0. This results in a Boltzmann factor of 1 for those positions, which is physically incorrect.

To address this, a large interaction energy value (1e10) is now assigned to inaccessible positions to ensure their Boltzmann factor becomes negligibly small.

## Impact on Results

### Henry coefficient
The value is computed as the sum of Boltzmann factors. This change can cause a minor difference since previously all inaccessible positions contributed a factor of 1. However, for most systems with predominantly negative interaction energies (leading to large Boltzmann factors), the impact mostly becomes negligible when a sufficiently large number of iterations is used.
See: [widom_insertion.py#L305](https://github.com/hspark1212/DAC-SIM/blob/5334be64f025dc3d9c9193510b79ae19a10f41fb/dac_sim/widom_insertion.py#L305)

### Heat of adsorption
In the original code, inaccessible positions were assigned an interaction energy of 0, which led to a Boltzmann factor of 1. Despite that, their contribution to the numerator was still 0 (since 0 * 1 = 0). 
With the updated approach, these positions are assigned a large energy value, resulting in a Boltzmann factor close to 0, again leading to a negligible contribution. Therefore, the heat of adsorption remains effectively unchanged.
See: [widom_insertion.py#L313](https://github.com/hspark1212/DAC-SIM/blob/5334be64f025dc3d9c9193510b79ae19a10f41fb/dac_sim/widom_insertion.py#L313)

Thanks to Pim de Haan for pointing out this issue!

